### PR TITLE
fix compile error: removed ambiguous overloads

### DIFF
--- a/native_huron/emitter.h
+++ b/native_huron/emitter.h
@@ -48,17 +48,7 @@ class Emitter : public Nan::ObjectWrap {
     }
   }
 
-  template<typename... Args>
-  void Emit (std::string eventName, const Args&... args) {
-    Emit(Nan::New(eventName).ToLocalChecked(), args...);
-  }
-
-  template<typename... Args>
-  void Emit (const char *eventName, const Args&... args) {
-    Emit(Nan::New(eventName).ToLocalChecked(), args...);
-  }
-
-  void Emit (std::string eventName, std::function<void(huron::Dictionary& dict)> fn) {
+  void Emit (std::string eventName, std::function<void(huron::Dictionary&)> fn) {
     uv_async_t *async = new uv_async_t();
     uv_async_init(uv_default_loop()
       , async
@@ -73,7 +63,7 @@ class Emitter : public Nan::ObjectWrap {
 		uv_async_send(async);
   }
 
-  void Emit (const char *eventName, std::function<void(huron::Dictionary& dict)> fn) {
+  void Emit (const char *eventName, std::function<void(huron::Dictionary&)> fn) {
     Emit(std::string(eventName), fn);
   }
 

--- a/native_huron/emitter.h
+++ b/native_huron/emitter.h
@@ -31,7 +31,7 @@ class Emitter : public Nan::ObjectWrap {
   };
 
   template<typename... Args>
-  void Emit (v8::Local<v8::Value> eventName, const Args&... args) {
+  void EmitJS (v8::Local<v8::Value> eventName, const Args&... args) {
     v8::String::Utf8Value name_(eventName->ToString());
     std::string name = std::string(*name_);
 
@@ -91,7 +91,7 @@ class Emitter : public Nan::ObjectWrap {
     huron::Dictionary dict = huron::Dictionary::CreateEmpty(iso);
     data.handler(dict);
 
-    data.self->Emit(Nan::New(data.event_name).ToLocalChecked()
+    data.self->EmitJS(Nan::New(data.event_name).ToLocalChecked()
       , huron::ConvertToV8(iso, dict));
 
     //delete handle; TODO: Consider the deletion of this.


### PR DESCRIPTION
using explicit `std::function<void(huron::Dictionary&)>` parameter caused compile error, because overload functions were ambiguous for the compiler. What are those overloads for btw?
