### PR TITLE
Emitter iterator invalidation fix

### DIFF
--- a/native_huron/emitter.h
+++ b/native_huron/emitter.h
@@ -40,8 +40,9 @@ class Emitter : public Nan::ObjectWrap {
     std::vector<v8::Local<v8::Value> > converted_args = { args..., };
 
     if (m.find(name) != m.end()) {
+      std::vector<internal::CopyablePersistentType> cb_vec_copy = m[name];
       for (std::vector<internal::CopyablePersistentType>::iterator
-        it = m[name].begin(); it != m[name].end(); ++it) {
+        it = cb_vec_copy.begin(); it != cb_vec_copy.end(); ++it) {
         node::MakeCallback(
           v8::Isolate::GetCurrent(), Nan::GetCurrentContext()->Global()
           , Nan::New(*it)
@@ -49,8 +50,9 @@ class Emitter : public Nan::ObjectWrap {
       }
     }
     if (o.find(name) != o.end()) {
+      std::vector<internal::CopyablePersistentType> cb_vec_copy = o[name];
       for (std::vector<internal::CopyablePersistentType>::iterator
-        it = o[name].begin(); it != o[name].end(); ++it) {
+        it = cb_vec_copy.begin(); it != cb_vec_copy.end(); ++it) {
         node::MakeCallback(
           v8::Isolate::GetCurrent(), Nan::GetCurrentContext()->Global()
           , Nan::New(*it)


### PR DESCRIPTION
Introducing solution for the following problem:

If you setup a js listener as follows, emitter will crash as its callback iterator goes invalid state
```js
emitter.on('event-name',
  function callbackFunction (event) {
    if (event.details === expectation) {
      emitter.removeListener('event-name', callbackFunction)
    }
  }
)
```
Here the listener removes itself by calling `Off`, thus invalidating `m[name]` vector in `Emit`'s processing cycle

Copying `m[name]` vector before iterating over it solves this problem

Also, added some checkers around `[]` operators to make sure we can't accidentally create unwanted elements in our maps and removed checkers from where it's not necessary.